### PR TITLE
アクティビティ間でデータの受け渡し

### DIFF
--- a/app/src/main/java/com/example/egame/MainActivity.kt
+++ b/app/src/main/java/com/example/egame/MainActivity.kt
@@ -1,13 +1,18 @@
 package com.example.egame
 
-import androidx.appcompat.app.AppCompatActivity
+import android.nfc.NfcAdapter.EXTRA_DATA
 import android.os.Bundle
+import android.preference.PreferenceManager
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.android.synthetic.main.activity_start.*
 
 class MainActivity : AppCompatActivity() {
+    val EXTRA_DATA = "com.example.testactivitytrasdata.DATA"
     private var king :String= "KING"
     private var joker :String = "JOKER"
-    private var playerPosition: String = king
+    private var playerPosition: String? = ""
     private var cpuPosition1: String? = ""
     private var cpuPosition2: String? = ""
     private var cpuPosition3: String? = ""
@@ -20,6 +25,7 @@ class MainActivity : AppCompatActivity() {
     private var draw : Boolean = false
     private var answered: Boolean = false
     private var roundLiset: Boolean = false
+    private var start : Boolean = true
     private var roundCount = 1
     private var playerWinCount  = 0
     private var cpuWinCount = 0
@@ -72,7 +78,25 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        setCard()
+        if(start) {
+
+            PreferenceManager.getDefaultSharedPreferences(this).apply {
+                val position = getString("position", "")
+                var tag = "Egame"
+                Log.d(tag, "position:" + position)
+                start = intent.getBooleanExtra(EXTRA_DATA, true)
+                //start = startString.toBoolean()
+                Log.d(tag, "start:" + start)
+                if (start) {
+                    playerPosition = position
+                    start = false
+                    setCard()
+                }
+
+
+            }
+        }
+
 
     }
 
@@ -223,7 +247,7 @@ class MainActivity : AppCompatActivity() {
         }
 
     }
-    fun setNextRound(playerPosition : String){
+    fun setNextRound(playerPosition : String?){
         //thisつけたらplayerPositionのval can'tのエラー消えた
         if(playerPosition == king) this.playerPosition = joker
         else this.playerPosition = king

--- a/app/src/main/java/com/example/egame/StartActivity.kt
+++ b/app/src/main/java/com/example/egame/StartActivity.kt
@@ -1,14 +1,19 @@
 package com.example.egame
 
+import android.nfc.NfcAdapter.EXTRA_DATA
+
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import kotlinx.android.synthetic.main.activity_main.*
+import android.preference.PreferenceManager
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.edit
 import kotlinx.android.synthetic.main.activity_start.*
 
 class StartActivity : AppCompatActivity() {
     private var positionNumber = 0
     var ready : Boolean = false
+    var start : Boolean = false
+    var startString : String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -17,9 +22,33 @@ class StartActivity : AppCompatActivity() {
         nextMainBtn.setOnClickListener {
             determinePosition()
             if (ready) {
-                val intent = Intent(this, MainActivity::class.java)
+                /*val intent = Intent(this, MainActivity::class.java)
                 startActivity(intent)
+                 */
+                PreferenceManager.getDefaultSharedPreferences(this).apply{
+                     start = getBoolean("start", true)
+
+
+                }
+                /*
+                if(start == true){
+                    startString = "true"
+                }else{
+                    startString = "false"
+                }
+                */
+
+                intent = Intent(this, MainActivity::class.java)
+                intent.putExtra("EXTRA_DATA", start)
+                startActivity(intent)
+                PreferenceManager.getDefaultSharedPreferences(this).apply {
+                    val editor = this.edit()
+                    editor.putBoolean("start", false)
+                        .apply()
+                }
+
             }
+            finish()
         }
     }
     fun determinePosition(){
@@ -34,8 +63,21 @@ class StartActivity : AppCompatActivity() {
             positionImage.setImageResource(R.drawable.joker)
             positionText.text = "JOKER"
         }
+        saveData()
+
 
         ready = true
+    }
+
+    fun saveData(){
+        val pref = PreferenceManager.getDefaultSharedPreferences(this)
+        val editor = pref.edit()
+        editor.putString("position", positionText.text.toString())
+            .putBoolean("start",true)
+            .apply()
+
+
+
     }
 
 }


### PR DESCRIPTION
StartActivityとMainActivityでのデータの受け渡しをできるようにした。ゲームを開始できる状態を保持するstartとプレイヤーのポジションを決めるpositionを扱った。startはバックグラウンドからフォアグラウンドにくる際に、onResume(setCard関数を呼び出してる)が呼び出されて処理が何回も起こるため用意した。